### PR TITLE
Fix TypeChecker and Runtime to handle plain object contexts and types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gresb/cel-javascript",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "description": "Parser and evaluator for Google's Common Expression Language (CEL) in JavaScript using ANTLR4",
   "main": "src/index.ts",
   "type": "module",

--- a/src/Context.ts
+++ b/src/Context.ts
@@ -1,25 +1,43 @@
 export default class Context {
     private variables: { [key: string]: any };
-    private types: { [key: string]: string };
+    private types: { [key: string]: any }; 
 
-    constructor(variables: { [key: string]: any } = {}, types: { [key: string]: string } = {}) {
+    constructor(variables: { [key: string]: any } = {}, types: { [key: string]: any } = {}) {
         this.variables = variables;
         this.types = types;
     }
 
     getVariable(name: string) {
-        return this.variables[name];
+        const parts = name.split('.');
+        let current = this.variables;
+        for (const part of parts) {
+            if (current && typeof current === 'object' && part in current) {
+                current = current[part];
+            } else {
+                return undefined;
+            }
+        }
+        return current;
     }
 
     getType(name: string) {
-        return this.types[name];
+        const parts = name.split('.');
+        let current = this.types;
+        for (const part of parts) {
+            if (current && typeof current === 'object' && part in current) {
+                current = current[part];
+            } else {
+                return undefined;
+            }
+        }
+        return current;
     }
 
     setVariable(name: string, value: any) {
         this.variables[name] = value;
     }
 
-    setType(name: string, type: string) {
+    setType(name: string, type: any) { 
         this.types[name] = type;
     }
 }

--- a/src/Runtime.ts
+++ b/src/Runtime.ts
@@ -59,11 +59,17 @@ export class Runtime {
         }
     }
     
-    static typeCheck(expression: string, typesContext: { [key: string]: any }): { success: boolean; error?: string } {
+    static typeCheck(expression: string, context?: any, types?: any): { success: boolean; error?: string } {
         const runtime: Runtime = new Runtime(expression);
         if (runtime.ast !== null) {
             try {
-                const typeChecker: TypeChecker = new TypeChecker(new Context(typesContext));
+                let contextObj: Context;
+                if (context instanceof Context) {
+                    contextObj = context;
+                } else {
+                    contextObj = new Context(context || {}, types || {});
+                }
+                const typeChecker: TypeChecker = new TypeChecker(contextObj);
                 typeChecker.visit(runtime.ast);
                 return { success: true };
             } catch (error) {
@@ -72,16 +78,16 @@ export class Runtime {
         } else {
             return { success: false, error: 'Parsing failed with errors' };
         }
-    }
+    }    
 
 
 
-    evaluate(context: any) {
+    evaluate(context: any, types?: any) {
         if (!this.ast) {
             throw new Error('AST is not available. Parsing might have failed.');
         }
-        const contextObj: Context = new Context(context);
-        const typeCheckResult = Runtime.typeCheck(this.celExpression, context);
+        const contextObj: Context = new Context(context, types);
+        const typeCheckResult = Runtime.typeCheck(this.celExpression, contextObj);
         if(typeCheckResult.success) {
             const evaluator: Evaluator = new Evaluator(contextObj);
             return evaluator.visit(this.ast);

--- a/tests/TypeChecker.test.ts
+++ b/tests/TypeChecker.test.ts
@@ -80,6 +80,32 @@ describe('TypeChecker Tests using Runtime', () => {
     expect(typeCheckResult.error).toContain("Argument 1 of function 'max' expects type 'int', but got 'string'");
   });
 
+  it('should be valid as the example of the readme', () => {
+    const expression = "user.age >= 18";
+    const context = {
+      user: {
+        name: 'Alice',
+        age: 20,
+      },
+    };
+    const typeCheckResult = Runtime.typeCheck(expression, context);
+    expect(typeCheckResult.success).toBe(true);
+  });
+
+  it('should be valid when we have multiple nested objects', () => {
+    const expression = "user.age.really >= 18";
+    const context = {
+      user: {
+        name: 'Alice',
+        age: {
+          really: 20
+        },
+      },
+    };
+    const typeCheckResult = Runtime.typeCheck(expression, context);
+    expect(typeCheckResult.success).toBe(true);
+  });
+
   it('should return correct type for logical NOT expression', () => {
     const expression = "!true";
     const typeCheckResult = Runtime.typeCheck(expression, {});

--- a/tests/evaluation.test.ts
+++ b/tests/evaluation.test.ts
@@ -202,4 +202,23 @@ describe('CEL Evaluation Tests', () => {
         const runtime = new Runtime(expression);
         expect(() => runtime.evaluate({})).toThrow('Mismatching types: Cannot compare \'int\' and \'float\' with \'<=\'');
     });
+
+    it('should return expected result in comparison of object properties', () => {
+        const expression = 'user.age >= 18';
+        const contextData = {
+            user: {
+                name: 'Alice',
+                age: 20,
+            },
+        };
+        const types = {
+            user: {
+                name: 'string',
+                age: 'int',
+            },
+        };
+        const runtime = new Runtime(expression);
+        const result = runtime.evaluate(contextData, types);
+        expect(result).toBe(true);
+    });
 });

--- a/tests/evaluation.test.ts
+++ b/tests/evaluation.test.ts
@@ -26,6 +26,19 @@ describe('CEL Evaluation Tests', () => {
         expect(result).toBe(true);
     });
 
+    it('should work with the readme example', () => {
+        const expression = "user.age >= 18";
+        const context = {
+            user: {
+                name: 'Alice',
+                age: 20,
+            },
+        };
+        const runtime = new Runtime(expression);
+        const result = runtime.evaluate(context);
+        expect(result).toBe(true);
+    });
+
     it('Should return error when a comparison has a type mismatch', () => {
         const expression = "2 == '2'";
         const runtime = new Runtime(expression);
@@ -201,24 +214,5 @@ describe('CEL Evaluation Tests', () => {
         const expression = "1 <= 2.3";
         const runtime = new Runtime(expression);
         expect(() => runtime.evaluate({})).toThrow('Mismatching types: Cannot compare \'int\' and \'float\' with \'<=\'');
-    });
-
-    it('should return expected result in comparison of object properties', () => {
-        const expression = 'user.age >= 18';
-        const contextData = {
-            user: {
-                name: 'Alice',
-                age: 20,
-            },
-        };
-        const types = {
-            user: {
-                name: 'string',
-                age: 'int',
-            },
-        };
-        const runtime = new Runtime(expression);
-        const result = runtime.evaluate(contextData, types);
-        expect(result).toBe(true);
     });
 });


### PR DESCRIPTION
This pull request resolves the issue where tests failed due to the TypeChecker expecting Context instances but receiving plain objects in the test setup. Now typechecker accepts both Context instances and plain objects for context and types.
Wraps plain objects into Context instances automatically.
