### PR TITLE
Fix module resolution error for antlr4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gresb/cel-javascript",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "description": "Parser and evaluator for Google's Common Expression Language (CEL) in JavaScript using ANTLR4",
   "main": "src/index.ts",
   "type": "module",

--- a/src/Runtime.ts
+++ b/src/Runtime.ts
@@ -1,4 +1,4 @@
-import antlr4 from 'antlr4';
+import * as antlr4 from 'antlr4';
 import CELLexer from './generated/CELLexer.js';
 import CELParser from './generated/CELParser.js';
 import Evaluator from './Evaluator';


### PR DESCRIPTION
This PR addresses the module importing error we had recently in one of the projects after updating Svelte. The error originated from how Vite’s underlying esbuild was handling antlr4. Since antlr4 does not provide a default export, the default import was causing issues during dependency pre-bundling.