### PR TITLE
Bump version to 0.0.22 in package.json and update package-lock.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ Here is a list of supported functions:
 
 ## Timestamp Handling and Relational Operators
 
-**New in v0.0.21:**  
+**New in v0.0.22:**  
 This release enhances the handling of timestamps and relational operators in the CEL evaluation system:
 
 - **Timestamp Comparisons:**  

--- a/package-lock.json
+++ b/package-lock.json
@@ -1033,15 +1033,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/@gresb/cel-javascript": {
-      "version": "0.0.21",
-      "resolved": "https://registry.npmjs.org/@gresb/cel-javascript/-/cel-javascript-0.0.20.tgz",
-      "integrity": "sha512-dpj6nSiDHAf84G6ER6RnBLzeSVIHfZd4nhehqavtXk14RrSB2l/l49cWQ5qRSN5Y/LJeIc1UOFKicRo2jC+gzA==",
-      "license": "unlicense",
-      "dependencies": {
-        "antlr4": "^4.13.2"
-      }
-    },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gresb/cel-javascript",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "description": "Parser and evaluator for Google's Common Expression Language (CEL) in JavaScript using ANTLR4",
   "main": "src/index.ts",
   "type": "module",


### PR DESCRIPTION
This pull request includes a minor version bump for the `@gresb/cel-javascript` package in the `package.json` file. The version has been updated from `0.0.21` to `0.0.22`.