### PR TITLE
Resolve CommonJS/ESM module compatibility issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gresb/cel-javascript",
-  "version": "0.0.24",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gresb/cel-javascript",
-      "version": "0.0.24",
+      "version": "0.1.0",
       "license": "unlicense",
       "dependencies": {
         "antlr4": "^4.13.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gresb/cel-javascript",
-  "version": "0.0.21",
+  "version": "0.0.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gresb/cel-javascript",
-      "version": "0.0.21",
+      "version": "0.0.24",
       "license": "unlicense",
       "dependencies": {
         "antlr4": "^4.13.2"
@@ -1031,15 +1031,6 @@
       ],
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/@gresb/cel-javascript": {
-      "version": "0.0.21",
-      "resolved": "https://registry.npmjs.org/@gresb/cel-javascript/-/cel-javascript-0.0.20.tgz",
-      "integrity": "sha512-dpj6nSiDHAf84G6ER6RnBLzeSVIHfZd4nhehqavtXk14RrSB2l/l49cWQ5qRSN5Y/LJeIc1UOFKicRo2jC+gzA==",
-      "license": "unlicense",
-      "dependencies": {
-        "antlr4": "^4.13.2"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
   "name": "@gresb/cel-javascript",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "description": "Parser and evaluator for Google's Common Expression Language (CEL) in JavaScript using ANTLR4",
-  "main": "src/index.ts",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "type": "module",
   "scripts": {
     "build": "tsc",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
   "name": "@gresb/cel-javascript",
-  "version": "0.0.24",
+  "version": "0.1.0",
   "description": "Parser and evaluator for Google's Common Expression Language (CEL) in JavaScript using ANTLR4",
   "main": "lib/index.js",
+  "exports": "./lib/index.js",
   "types": "lib/index.d.ts",
   "type": "module",
   "scripts": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,13 @@
 {
   "compilerOptions": {
-    "target": "ES6",
-    "module": "commonjs",
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "node",
     "declaration": true,
     "outDir": "./lib",
     "strict": true,
     "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "typeRoots": ["./node_modules/@types", "./typings"]


### PR DESCRIPTION
After rebasing the data-dictionary application from main and upgrading cel-javascript from v0.0.22 to v0.0.23, the application began failing with module import errors. The dependency upgrade exposed a module system incompatibility that prevented the data-dictionary frontend from building and running tests.

The cel-javascript library v0.0.23 introduced a module system mismatch during the dependency update:
- `package.json` declared `"type": "module"` (indicating ES modules), however, `tsconfig.json` was still configured to output CommonJS format

This created a conflict causing "SyntaxError: Unexpected token 'exports'" errors when importing in the data-dictionary's Vite environment

**Changes made:**

I fixed the module system mismatch by aligning the TypeScript compiler output with the [package.json] module declaration. 