### PR TITLE
Use TypeScript source as main entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,8 @@
 {
   "name": "@gresb/cel-javascript",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Parser and evaluator for Google's Common Expression Language (CEL) in JavaScript using ANTLR4",
-  "main": "lib/index.js",
-  "exports": "./lib/index.js",
-  "types": "lib/index.d.ts",
+  "main": "src/index.ts",
   "type": "module",
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
- Change main from 'lib/index.js' to 'src/index.ts'
- Remove exports and types fields to use TypeScript source directly
- This fixes build issues when consuming the package in other projects
- Tested with npm link in data-dictionary - no more Runtime/Evaluator resolve errors